### PR TITLE
Feature: Add additional question data to `/users` routes.

### DIFF
--- a/src/services/userQuestionDataScraper/src/packages/userQuestionDataScraper/userQuestionDataScraper.ts
+++ b/src/services/userQuestionDataScraper/src/packages/userQuestionDataScraper/userQuestionDataScraper.ts
@@ -1,5 +1,11 @@
 import axios, { AxiosResponse } from "axios";
 
+const difficulty: {[key: string]: number} = {
+	"Easy": 0,
+	"Medium": 1,
+	"Hard": 2
+};
+
 /**
  * Gets an object containing a users information and question statuses from leetcodes graphql client.
  * @param session - User to scrape's leetcode session token.
@@ -13,7 +19,7 @@ const scrape = async (session: string): Promise<{
 	questions: Array<{
 		isCompleted: boolean,
 		hasBeenAttempted: boolean,
-		difficulty: string,
+		difficulty: number,
 		questionTitle: string,
 		questionTitleSlug: string,
 		questionId: number,
@@ -49,7 +55,7 @@ const scrape = async (session: string): Promise<{
 			questions: questions.map(question => ({
 				isCompleted: question.status === "ac",
 				hasBeenAttempted: question.status !== null,
-				difficulty: question.difficulty,
+				difficulty: difficulty[question.difficulty],
 				questionTitle: question.questionTitle,
 				questionTitleSlug: question.questionTitleSlug,
 				questionId: parseInt(question.questionId),

--- a/src/services/users/src/controllers/users.ts
+++ b/src/services/users/src/controllers/users.ts
@@ -59,15 +59,32 @@ export default class UsersController {
 
 		const username = user.username;
 		const userQuestionData: Array<iUserQuestionData> = await UserQuestionData.find({ username });
+		const completed = [0, 0, 0];
+		let total = 0;
+
+		userQuestionData.forEach(question => {
+			if (question.isCompleted) {
+				total++;
+				completed[question.questionDifficulty]++;
+			}
+		});
+
 		return ({
 			message: "Successfully fetched user with username " + username,
 			user: {
 				username,
 				avatar: user.avatar,
 				is_premium: user.isPremium,
-				accepted: userQuestionData.filter(question => question.isCompleted).length,
+				accepted: {
+					total,
+					easy: completed[0],
+					medium: completed[1],
+					hard: completed[2]
+				},
 				question_statuses: userQuestionData.map(question => ({
+					id: question.questionId,
 					title: question.questionTitle,
+					difficulty: question.questionDifficulty,
 					isCompleted: question.isCompleted,
 					hasBeenAttempted: question.hasBeenAttempted
 				}))

--- a/src/services/users/src/models/userQuestionData.ts
+++ b/src/services/users/src/models/userQuestionData.ts
@@ -11,6 +11,11 @@ export interface iUserQuestionData {
 	username: string;
 
 	/**
+	 * Number value indicating the associated questions id.
+	 */
+	questionId: number;
+
+	/**
 	 * String value indicating a questions title. Used to map back to a given question.
 	 */
 	questionTitle: string;
@@ -34,6 +39,7 @@ export interface iUserQuestionData {
 
 const UserQuestionDataSchema: Schema<iUserQuestionData> = new Schema({
 	username: { type: "string", required: true },
+	questionId: { type: "number", required: true },
 	questionTitle: { type: "string", required: true },
 	questionDifficulty: { type: "number", required: true },
 	isCompleted: { type: "boolean", required: true },


### PR DESCRIPTION
* Feature: Add number of completed problems for `total`, `easy`, `medium`, and `hard` for `/users` routes.
* Rework: Change `difficulty` on `userQuestionDataScraper` service to map from `string` to `number`.
* Closes #20 